### PR TITLE
Fixed transcription error for es model data

### DIFF
--- a/models.yml
+++ b/models.yml
@@ -21,7 +21,7 @@ stt_models:
   es:
     latest:
       meta:
-        name: "de_v1"
+        name: "es_v1"
       labels: "https://silero-models.ams3.cdn.digitaloceanspaces.com/models/es/es_v1_labels.json"
       jit: "https://silero-models.ams3.cdn.digitaloceanspaces.com/models/es/es_v1_jit.model"
       onnx: "https://silero-models.ams3.cdn.digitaloceanspaces.com/models/es/es_v1_batchless.onnx"


### PR DESCRIPTION
Just a minor error I noticed in the models.yml file: the spanish and german blocks have the same name.