### PR TITLE
Fix model downloading and loading

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -1,3 +1,4 @@
+import os
 import torch
 import tempfile
 import warnings
@@ -121,10 +122,16 @@ class Decoder():
 def init_jit_model(model_url: str,
                    device: torch.device = torch.device('cpu')):
     torch.set_grad_enabled(False)
-    with tempfile.NamedTemporaryFile('wb', suffix='.model') as f:
+
+    model_dir = os.path.join(os.path.dirname(__file__), "model")
+    os.makedirs(model_dir, exist_ok=True)
+    model_path = os.path.join(model_dir, os.path.basename(model_url))
+
+    if not os.path.isfile(model_path):
         torch.hub.download_url_to_file(model_url,
-                                       f.name,
+                                       model_path,
                                        progress=True)
-        model = torch.jit.load(f.name, map_location=device)
-        model.eval()
+
+    model = torch.jit.load(model_path, map_location=device)
+    model.eval()
     return model, Decoder(model.labels)


### PR DESCRIPTION
- FIX: In Windows, it is raising PermissionError when running code using `torchhub`.

      
      (test_env) C:\proj\silero_speech>C:/Users/kartikey/.conda/envs/test_env/python.exe c:/proj/silero_speech/silero_test.py
      C:\Users\kartikey\.conda\envs\test_env\lib\site-packages\torchaudio\extension\extension.py:14: UserWarning: torchaudio C++ extension is not available.
        warnings.warn('torchaudio C++ extension is not available.')
      Using cache found in C:\Users\kartikey/.cache\torch\hub\snakers4_silero-models_master
      100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████| 174M/174M [00:48<00:00, 3.79MB/s]
      Traceback (most recent call last):
        File "C:\Users\kartikey\.conda\envs\test_env\lib\shutil.py", line 544, in move
          os.rename(src, real_dst)
      FileExistsError: [WinError 183] Cannot create a file when that file already exists: 'C:\\Users\\kartikey\\AppData\\Local\\Temp\\tmpmqzwrhr1' -> 'C:\\Users\\kartikey\\AppData\\Local\\Temp\\tmpe8da6qp9.model'
      
      During handling of the above exception, another exception occurred:
      
      Traceback (most recent call last):
        File "c:/proj/silero_speech/silero_test.py", line 11, in <module>
          device=device)
        File "C:\Users\kartikey\.conda\envs\test_env\lib\site-packages\torch\hub.py", line 353, in load
          model = entry(*args, **kwargs)
        File "C:\Users\kartikey/.cache\torch\hub\snakers4_silero-models_master/hubconf.py", line 25, in silero_stt
          **kwargs)
        File "C:\Users\kartikey/.cache\torch\hub\snakers4_silero-models_master\utils.py", line 141, in init_jit_model
          progress=True)
        File "C:\Users\kartikey\.conda\envs\test_env\lib\site-packages\torch\hub.py", line 415, in download_url_to_file
          shutil.move(f.name, dst)
        File "C:\Users\kartikey\.conda\envs\test_env\lib\shutil.py", line 558, in move
          copy_function(src, real_dst)
        File "C:\Users\kartikey\.conda\envs\test_env\lib\shutil.py", line 257, in copy2
          copyfile(src, dst, follow_symlinks=follow_symlinks)
        File "C:\Users\kartikey\.conda\envs\test_env\lib\shutil.py", line 121, in copyfile
          with open(dst, 'wb') as fdst:
      PermissionError: [Errno 13] Permission denied: 'C:\\Users\\kartikey\\AppData\\Local\\Temp\\tmpe8da6qp9.model'
      
      
- Avoid downloading of model at every run.