### PR TITLE
Fix tts example

### DIFF
--- a/examples_tts.ipynb
+++ b/examples_tts.ipynb
@@ -77,8 +77,8 @@
     "print(f'Available languages {available_languages}')\n",
     "\n",
     "for lang in available_languages:\n",
-    "    speakers = list(models.tts_models.get(lang).keys())\n",
-    "    print(f'Available speakers for {lang}: {speakers}')"
+    "    models = list(models.tts_models.get(lang).keys())\n",
+    "    print(f'Available models for {lang}: {models}')"
    ]
   },
   {


### PR DESCRIPTION
`models.tts_models.get(lang)` returns model names while `model.speakers` returns speaker names.

A user might make a mistake when trying to change the language/speaker, thinking e. g. "v3_en" is a speaker.

Example old output:

```
Available speakers for en: ['v3_en', 'v3_en_indic', 'lj_v2', 'lj_8khz', 'lj_16khz']
```

How it should be:

```
Available models for en: ['v3_en', 'v3_en_indic', 'lj_v2', 'lj_8khz', 'lj_16khz']
```

