### PR TITLE
FIX potential memory error with torch.ones in tts_utils..py

### DIFF
--- a/src/silero/tts_utils.py
+++ b/src/silero/tts_utils.py
@@ -58,7 +58,8 @@ def prepare_tts_model_input(text: str or list, symbols: str):
     max_input_len = input_lengths[0]
     batch_size = len(text_tensors)
 
-    text_padded = torch.ones(batch_size, max_input_len, dtype=torch.int32)
+    # text_padded = torch.ones(batch_size, max_input_len, dtype=torch.int32)
+    text_padded = torch.ones(batch_size, max_input_len, dtype=torch.long)
 
     for i, idx in enumerate(ids_sorted_decreasing):
         text_tensor = text_tensors[idx]


### PR DESCRIPTION
Passed the torch.ones to torch long instead of torch.32 so that they are in the same size as the tokens that are passed to the model.